### PR TITLE
Replace dunstify with notify-send for universal notification support

### DIFF
--- a/phototransfer
+++ b/phototransfer
@@ -1,25 +1,28 @@
 #!/usr/bin/env bash
 
+# Use dunstify if available, otherwise fall back to notify-send
+NOTIFY_CMD=$(which dunstify || which notify-send)
+
 folder=~/
 
 mount() { # Check if the card is mounted
-		[ -d /mnt/sdcard/DCIM/ ] || notify-send "Card not mounted."
+		[ -d /mnt/sdcard/DCIM/ ] || $NOTIFY_CMD "Card not mounted."
 }
 
 
 unmount() { # Unmount card
-		sudo systemd-mount --unmount /mnt/sdcard && notify-send "Card unmounted."
+		sudo systemd-mount --unmount /mnt/sdcard && $NOTIFY_CMD "Card unmounted."
 }
 
 
 dt() { # Open darktable to import today's photos
-		sudo systemd-mount --unmount /mnt/sdcard && notify-send "Card unmounted; opening Darktable"
+		sudo systemd-mount --unmount /mnt/sdcard && $NOTIFY_CMD "Card unmounted; opening Darktable"
 		(darktable "$folder$(date '+%b_%d')") &
 }
 
 
 postrun() { # Menu to select what I want to do after photos have been transferred
-		notify-send "Photos have transferred."
+		$NOTIFY_CMD "Photos have transferred."
 		choice=$(printf "Unmount card\\nOpen Darktable, unmount\\nDo nothing" | dmenu -c -l 3 -i -p "Photos have transferred: ")
 		case "$choice" in
 				Unmount*) unmount;;
@@ -31,7 +34,7 @@ postrun() { # Menu to select what I want to do after photos have been transferre
 
 auto() { # Transfer photos from SD card into a directory for today's date
 		[ -d /mnt/sdcard/DCIM/ ] || exit 0
-		notify-send "Photo transfer starting..."
+		$NOTIFY_CMD "Photo transfer starting..."
 
 		mkdir -p "$folder$(date '+%b_%d')"
 		find /mnt/sdcard -type f -name "*.CR2" -exec mv -nv {} "$folder$(date '+%b_%d')/" \; && postrun
@@ -44,4 +47,3 @@ case "$1" in
 		dt) dt ;;
 		*) auto ;;
 esac
-

--- a/phototransfer
+++ b/phototransfer
@@ -3,23 +3,23 @@
 folder=~/
 
 mount() { # Check if the card is mounted
-		[ -d /mnt/sdcard/DCIM/ ] || dunstify "Card not mounted."
+		[ -d /mnt/sdcard/DCIM/ ] || notify-send "Card not mounted."
 }
 
 
 unmount() { # Unmount card
-		sudo systemd-mount --unmount /mnt/sdcard && dunstify "Card unmounted."
+		sudo systemd-mount --unmount /mnt/sdcard && notify-send "Card unmounted."
 }
 
 
 dt() { # Open darktable to import today's photos
-		sudo systemd-mount --unmount /mnt/sdcard && dunstify "Card unmounted; opening Darktable"
+		sudo systemd-mount --unmount /mnt/sdcard && notify-send "Card unmounted; opening Darktable"
 		(darktable "$folder$(date '+%b_%d')") &
 }
 
 
 postrun() { # Menu to select what I want to do after photos have been transferred
-		dunstify "Photos have transferred."
+		notify-send "Photos have transferred."
 		choice=$(printf "Unmount card\\nOpen Darktable, unmount\\nDo nothing" | dmenu -c -l 3 -i -p "Photos have transferred: ")
 		case "$choice" in
 				Unmount*) unmount;;
@@ -31,7 +31,7 @@ postrun() { # Menu to select what I want to do after photos have been transferre
 
 auto() { # Transfer photos from SD card into a directory for today's date
 		[ -d /mnt/sdcard/DCIM/ ] || exit 0
-		dunstify "Photo transfer starting..."
+		notify-send "Photo transfer starting..."
 
 		mkdir -p "$folder$(date '+%b_%d')"
 		find /mnt/sdcard -type f -name "*.CR2" -exec mv -nv {} "$folder$(date '+%b_%d')/" \; && postrun
@@ -44,3 +44,4 @@ case "$1" in
 		dt) dt ;;
 		*) auto ;;
 esac
+


### PR DESCRIPTION
Replaced dunstify with notify-send to improve script compatibility across systems that don't have Dunst installed. This change allows the photo transfer notifications to work on any Linux system with a standard notification daemon.