### PR TITLE
dmenu_musicpicker: Use `mpc listall`

### DIFF
--- a/dmenu_musicpicker
+++ b/dmenu_musicpicker
@@ -3,10 +3,6 @@
 # mpc (and mpd) seem to have trouble with complex filenames. still working on a solution to this
 # relative path to mpd's music directory *must* be used. absolute path will not be read by mpd.
 
-		if command -v fd >/dev/null; then 
-				file=$(fd .mp3 ~/Music -p -t f | sed "s|^/home/$USER/Music/||" | dmenu -i -l 1) || exit 0
-		else 
-				file=$(find ~/Music -type f -name "*.mp3" | sort | sed "s|^/home/$USER/Music/||" | dmenu -i -l 1) || exit 0
-		fi
+file="$(mpc listall | dmenu -i -l 1)" || exit 0
 
 notify-send "Playing $file" && mpc insert "$file" && mpc next >/dev/null


### PR DESCRIPTION
Instead of using `find` or `fd` to walk the music directory, use `mpc listall` to query mpd's database for a list of songs to add.  This is a lot faster, works on all song files (instead of just .mp3), and is more portable (in case you change the location of your music directory.)  It also drops the dependency check for `fd`.
