### PR TITLE
Refactor screenshot scripts: Practical Cleanup & Features

### DIFF
--- a/screenshot
+++ b/screenshot
@@ -1,28 +1,29 @@
 #!/usr/bin/env bash
-
-### Full credit for this script to https://github.com/TheGassyNinja
+# Based on original script by https://github.com/TheGassyNinja
+set -euo pipefail
 export DISPLAY=:0
-current=$(date +%H-%M-%S-%d-%m-%Y).png
-filepath="${HOME}/${current}"
+
+# Output directory: default to $HOME/Screenshots
+OUTDIR="${1:-${HOME}/Screenshots}"
+mkdir -p "${OUTDIR}"
+
+current="$(date +%Y%m%d_%H%M%S).png"
+filepath="${OUTDIR}/${current}"
 
 # Determine screenshot utility
-if command -v import &> /dev/null; then
-    TOOL="import"
-elif command -v scrot &> /dev/null; then
-    TOOL="scrot"
-else
-    notify-send "Screenshot Tool Missing" "Neither ImageMagick (import) nor scrot is installed!"
-    echo "Error: No screenshot tool found (import or scrot)."
-    exit 1
-fi
+tool_path="$(command -v import 2>/dev/null || command -v scrot 2>/dev/null)" || {
+    notify-send "Screenshot Tool Missing" "Neither 'import' nor 'scrot' is installed!"
+    echo "Error: No screenshot tool found."; exit 1;
+}
+TOOL="$(basename "${tool_path}")"
 
+# Select flags based on tool and optional "-s" argument
 flags=()
-if [[ "$TOOL" == "import" ]] && [[ -z "${1}" ]]; then
-    flags=(-window root)
-elif [[ "$TOOL" == "scrot" ]] && [[ -n "${1}" ]]; then
-    flags=(--select)
-fi
-"$TOOL" "${flags[@]}" "$filepath" || exit 1
+[[ "${TOOL}" == "scrot" && "${2:-}" == "-s" ]] && flags=(--select)
+[[ "${TOOL}" == "import" && "${2:-}" != "-s" ]] && flags=(-window root)
 
-notify-send "Screenshot Taken" "Saved as ${current} in ${HOME}"
-
+"$TOOL" "${flags[@]}" "${filepath}" || {
+    notify-send "Screenshot Failed" "Could not save screenshot to ${filepath}."
+    exit 1
+}
+notify-send "Screenshot Taken" "Saved as ${current} in ${OUTDIR}"

--- a/screenshot_extra_features
+++ b/screenshot_extra_features
@@ -1,59 +1,76 @@
 #!/usr/bin/env bash
+# Screenshot script with color picker, clipboard copy, and optional watermark
+# Usage: $0 [color|full|window] [output_dir]
 
-# expansion of the imagemagick screenshot script with:
-# - hex code color picker (slop + imagemagick)
-# - copy to clipboard (xclip)
-# - screenshot current window directly (no selection)
-
+set -euo pipefail
 export DISPLAY=:0
-FILE="$HOME/$(date +%F___%T | tr ':' '-').png"
 
-colorpicker () { # click a pixel OR draw a selection for average color, returned in a notif & copied to clip
-TMP="/tmp/color.png"
+# Dependencies check
+for cmd in xclip import notify-send; do
+    command -v "$cmd" &>/dev/null || { echo "Missing: $cmd" >&2; exit 1; }
+done
 
-# slop's tolerance flag controls how far mouse can be move before being detected as a click and drag
-# would recommend use of slop as it allows for 1x1 selection
-if command -v slop >/dev/null; then 
-		import -window root -crop "$(slop --tolerance=0 || exit 0)" "$TMP"
-else 
-		import "$TMP"
-fi
+OUTDIR="${2:-$HOME/Screenshots}"
+mkdir -p "$OUTDIR"
+FILE="$OUTDIR/$(date +%Y%m%d_%H%M%S).png"
+TMP="$(mktemp --suffix=.png /tmp/colorpicker.XXXXXX)"; trap 'rm -f "$TMP"' EXIT
 
-HEX=$(magick "$TMP" -scale 1x1\! -format "#%[hex:p{0,0}]" info:) # SRGB: '%[pixel:p{0,0}]'
+post() {
+    if [[ "${WATERMARK:-}" == "1" ]]; then
+        command -v magick &>/dev/null || { echo "Missing: magick (required for watermark)" >&2; exit 1; }
 
-notify-send -i "$TMP" $HEX # set the tmp img as the notif icon
-echo "$HEX" | xclip -i -selection clipboard # copy to clip
-rm "$TMP"
+        # Watermark subsystem (env overrides supported)
+        local text="${WATERMARK_TEXT:-$(date '+%Y-%m-%d %H:%M')}" \
+              pos="${WATERMARK_POS:-southeast}" \
+              size="${WATERMARK_SIZE:-28}" \
+              bg="${WATERMARK_BG:-#00000080}"
+
+        magick "$FILE" \
+            -gravity "$pos" \
+            -pointsize "$size" \
+            -fill white \
+            -undercolor "$bg" \
+            -annotate +20+20 "$text" \
+            "$FILE"
+    fi
+
+    xclip -selection clipboard -t image/png -i "$FILE" &&
+    notify-send -i "$FILE" "Screenshot: $(basename "$FILE")"
 }
 
 
-full () { # full screen incl. all monitors
-		import -window root "$FILE" && post
+colorpicker() {
+    command -v magick &>/dev/null || { notify-send "Missing: magick"; exit 1; }
+
+    if command -v slop &>/dev/null; then
+        selection=$(slop --tolerance=0) || exit 1
+        import -window root -crop "$selection" "$TMP"
+    else
+        import "$TMP"
+    fi
+
+    local hex
+    hex=$(magick "$TMP" -scale 1x1\! -format "#%[hex:p{0,0}]" info: 2>/dev/null || echo "#??????")
+    echo "$hex" | xclip -selection clipboard -i && notify-send -i "$TMP" "Color: $hex"
+    rm -f "$TMP"
 }
-
-
-window () { # focused window
-		import -window "$(xdotool getwindowfocus -f)" "$FILE"
-}
-
-
-selection () { # draw a selection, or click to select a window
-		import "$FILE" && post
-}
-
-
-post () { # copy image to clip & send a notification
-		xclip -selection clipboard -t image/png -i $FILE && notify-send -i "$FILE" "$FILE copied to clipboard"
-}
-
-
-case "$1" in
-		color*) colorpicker ;;
-		full) full ;;
-		window) window ;;
-		*) selection ;;
+case "${1:-}" in
+    -h|--help)
+        echo "Usage: $0 [color|full|window] [output_dir]"
+        echo
+        echo "Environment options:"
+        echo "  WATERMARK=1                  Enable timestamp/text watermark"
+        echo "  WATERMARK_TEXT='text'        Custom watermark text"
+        echo "  WATERMARK_POS=position       Position (e.g. southeast, northwest)"
+        echo "  WATERMARK_SIZE=px            Font size"
+        echo "  WATERMARK_BG='#rrggbbaa'     Background color (e.g '#00000080')"
+        exit 0
+        ;;
+    color*) colorpicker ;;
+    full) import -window root "$FILE" && post ;;
+    window)
+        command -v xdotool &>/dev/null || { echo "Missing: xdotool" >&2; exit 1; }
+        import -window "$(xdotool getwindowfocus -f)" "$FILE" && post
+        ;;
+    *) import "$FILE" && post ;;
 esac
-
-# watermark automation example
-# !! repage for centered gravity when screenshotting a selection !!
-# import png:- | magick - +repage -gravity center -fill white -undercolor '#00000080' -pointsize 50 -annotate 0 'bread' watermark.png


### PR DESCRIPTION
Made a couple of improvements to both scripts. Mostly for consistency, robustness, and usability. Just a bit of cleaning before summer for the Bash basement.

**Changes to screenshot:**

- Safer execution with set -euo pipefail, a common best practice for writing more reliable scripts.
- Added support for a custom output directory, Automatically creates the folder if it doesn't exist. (default: $HOME/Screenshots)
- Slightly cleaner logic for tool detection (import or scrot), with proper fallback and flags & Improved notifications and output paths for clarity.

**Changes to screenshot_extra_features:**

- Added safety features (set -euo pipefail, quoting, temp file cleanup with trap).
- Modularized with functions + case block for clearer structure.
- Cleaned up the color picker: works the same, just more stable and predictable.
- Implemented watermark support based on the example in the original comments. Now optional and customizable via environment variables

a bit more robust and user-friendly, especially for folks who might want to reuse or extend them later. Merge or tweak to taste!