### PR TITLE
Refactor audio_switch script: Pipewire and Bluetooth Connectivity

### DIFF
--- a/dmenu_audioswitch_prev
+++ b/dmenu_audioswitch_prev
@@ -1,19 +1,55 @@
 #!/usr/bin/env bash
 # Set audio sinks before using!
 # `pactl list sinks` if on pulseaudio.
+# `wpctl status` if on pipewire
+
+set_source() { \
+  local SINK_NAME=$1
+  local PIPEWIRE=0
+  local PULSEAUDIO=0
+
+  if [ "$(systemctl --user is-active pipewire)" = "active" ]; then
+    PIPEWIRE=1
+  elif [ "$(systemctl --user is-active pulseaudio)" = "active" ]; then
+    PULSEAUDIO=1
+  fi
+  if [ $PULSEAUDIO -eq 1 ]; then
+    pacmd set-default-sink $SINK_NAME &
+  elif [ $PIPEWIRE -eq 1 ]; then
+    wpctl set-default $SINK_NAME
+  fi
+}
+
+enable_and_connect() {
+  local B_NAME=$1
+  if [ $(bluetoothctl show | grep Powered | awk '{print $2}') == "no" ]; then
+    echo "Bluetooth is disabled"
+    echo "Enabling Bluetooth..."
+    bluetoothctl power on > /dev/null
+  fi
+  local DEVICE=$(bluetoothctl devices | grep -w $B_NAME | awk '{print $2}')
+  if [ -z "$DEVICE" ]; then
+    echo "Device not found: $B_NAME"
+    return 1
+  fi
+  if bluetoothctl info "$DEVICE" | grep -q "Connected: no"; then  
+    bluetoothctl connect $DEVICE > /dev/null
+  fi
+}
 
 headphones () { \
-  pacmd set-default-sink "SET SINK NAME" &
+  set_source "SET SINK NAME OR DEVICE ID"
   notify-send  -h string:bgcolor:#a3be8c "Audio switched to headphones!"
 }
 
 speakers () { \
-  pacmd set-default-sink "SET SINK NAME" &
+  set_source "SET SINK NAME OR DEVICE ID"
   notify-send  -h string:bgcolor:#bf616a "Audio switched to speakers!"
 }
 
 bluetooth () { \
-  pacmd set-default-sink "SET SINK NAME" &
+  enable_and_connect "SET NAME OF YOUR BLUETOOTH DEVICE"
+  set_source "SET SINK NAME OR DEVICE ID"
   notify-send  -h string:bgcolor:#88c0d0 "Audio switched to bluetooth!"
 }
 

--- a/dmenu_audioswitch_prev
+++ b/dmenu_audioswitch_prev
@@ -9,14 +9,9 @@ set_source() { \
   local PULSEAUDIO=0
 
   if [ "$(systemctl --user is-active pipewire)" = "active" ]; then
-    PIPEWIRE=1
-  elif [ "$(systemctl --user is-active pulseaudio)" = "active" ]; then
-    PULSEAUDIO=1
-  fi
-  if [ $PULSEAUDIO -eq 1 ]; then
-    pacmd set-default-sink $SINK_NAME &
-  elif [ $PIPEWIRE -eq 1 ]; then
     wpctl set-default $SINK_NAME
+  elif [ "$(systemctl --user is-active pulseaudio)" = "active" ]; then
+    pacmd set-default-sink $SINK_NAME &
   fi
 }
 

--- a/dmenu_audioswitch_prev
+++ b/dmenu_audioswitch_prev
@@ -49,6 +49,7 @@ bluetooth () { \
 }
 
 choosespeakers() { \
+  # If the script is not rendering in dmenu, remove the `-c` flag from dmenu commands.
   choice=$(printf "Headphones\\nSpeakers\\nBluetooth" | dmenu -c -l 3 -i -p "Choose output: ")
   case "$choice" in
     Headphones) headphones;;


### PR DESCRIPTION
Hey, really loved your scripts, so i decide to make some changes to the `dmenu_audioswitch_prev` script with improved audio device switching capabilities and broader compatibility.

## Changes
- **PipeWire Support**: Added native PipeWire compatibility alongside existing PulseAudio support
- **Bluetooth Integration**: Implemented automatic Bluetooth device connectivity handling
- **Code Refactoring**: Restructured script for better modularity, readability, and maintainability

## Testing
- Tested successfully on my dmenu rice
- Would appreciate testing on other configurations to ensure compatibility

## Impact
These changes make the script more versatile for modern Linux audio setups while maintaining backward compatibility with existing PulseAudio workflows.

