### PR TITLE
dmenu_notes: Allow sub-directories

### DIFF
--- a/dmenu_notes
+++ b/dmenu_notes
@@ -3,13 +3,17 @@
 folder=$HOME/notes/
 
 newnote () { \
+  dir="$(command ls -d "$folder" "$folder"*/ | dmenu -c -l 5 -i -p 'Choose directory: ')"|| exit 0
+  : "${dir:=$folder}"
   name="$(echo "" | dmenu -c -sb "#a3be8c" -nf "#d8dee9" -p "Enter a name: " <&-)" || exit 0
   : "${name:=$(date +%F_%H-%M-%S)}"
-  setsid -f "$TERMINAL" -e nvim $folder$name".md" >/dev/null 2>&1
+  setsid -f "$TERMINAL" -e nvim $dir$name".md" >/dev/null 2>&1
 }
 
 selected () { \
-  choice=$(echo -e "New\n$(command ls -t1 $folder)" | dmenu -c -l 5 -i -p "Choose note or create new: ")
+  choice=$(
+    echo -e "New\n$(find $folder -type f -printf '%T@ %P\n' | sort -nr | cut -d' ' -f2-)" | dmenu -c -l 5 -i -p "Choose note or create new: "
+  )
   case $choice in
     New) newnote ;;
     *.md) setsid -f "$TERMINAL" -e nvim "$folder$choice" >/dev/null 2>&1 ;;


### PR DESCRIPTION
A small change that allows sub-directories. It prompts user for new/select note as before but then lists the directories inside `$folder` for new note. Feel free to close the PR if this doesn't suit your need :)