### PR TITLE
Fix define selection behavior on Wayland

### DIFF
--- a/shortcuts-menus/define
+++ b/shortcuts-menus/define
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-word=${1:-$(xclip -o -selection primary 2>/dev/null || wl-paste 2>/dev/null)}
+word=${1:-$(xclip -o -selection primary 2>/dev/null || wl-paste --primary 2>/dev/null)}
 
 # Check for empty word or special characters
 [[ -z "$word" || "$word" =~ [\/] ]] && notify-send -h string:bgcolor:#bf616a -t 3000 "Invalid input." && exit 0


### PR DESCRIPTION
Added the --primary flag to wl-paste. 
Without it, wl-paste uses the regular clipboard, which requires actually copying a word first.  The "primary" clipboard is the selection-based one, which I think is intended to be used with this script.